### PR TITLE
fix(app-fetch): align appFetch signature with RPC client requirements

### DIFF
--- a/web/src/lib/app-fetch.ts
+++ b/web/src/lib/app-fetch.ts
@@ -1,6 +1,12 @@
-export const appFetch = async (input: RequestInfo, init: RequestInit = {}) => {
-    const token = localStorage.getItem('access_token')
+import type { ExecutionContext } from "hono"
 
+export const appFetch: (
+    input: URL | RequestInfo,
+    init?: RequestInit,
+    Env?: any,
+    executionCtx?: ExecutionContext
+) => Promise<Response> = async (input, init = {}, _env?, _executionCtx?) => {
+    const token = localStorage.getItem('access_token')
     const headers = new Headers(init.headers || {})
     if (token) {
         headers.set('Authorization', `${token}`)


### PR DESCRIPTION
- update appFetch type signature to accept (input, init, Env?, executionCtx?)
- ensure compatibility with Hono/TanStack RPC client fetch interface
- keep existing logic for auth header, content-type handling, and error parsing