### PR TITLE
featfix(recordings): fetch recordings by user token instead of all data

### DIFF
--- a/src/modules/recordings/recordings.repository.ts
+++ b/src/modules/recordings/recordings.repository.ts
@@ -1,6 +1,7 @@
 
 import { db } from '../../config/db/index.js'
-import { recordingTable, type Recording } from '../../config/db/schema/postgres.js'
+import { recordingTable, streakTable, type Recording } from '../../config/db/schema/postgres.js'
+import { JWTService } from '../../lib/middleware/jwt.js'
 import type { BaseRepository } from '../../lib/repository.js'
 import { eq } from 'drizzle-orm'
 
@@ -63,6 +64,24 @@ export class RecordingsRepository implements BaseRepository<RecordEntity> {
             console.error(error)
             return false
         }
+    }
+
+    async findByUserId(userId: number) {
+        const streaks = await db
+            .select()
+            .from(streakTable)
+            .where(
+                eq(streakTable.user, userId)
+            )
+        return streaks.length > 0 ? streaks[0] : null
+    }
+
+    async findByToken(token: string) {
+        const claims = JWTService.decode(token)
+        if (claims && claims.sub) {
+            return this.findByUserId(Number(claims.sub))
+        }
+        return null
     }
 }
 

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/vite": "^4.1.12",
         "@tanstack/react-query": "^5.85.9",

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/web/src/routes/dashboard.tsx
+++ b/web/src/routes/dashboard.tsx
@@ -38,7 +38,7 @@ function DashboardPage() {
     } = useQuery({
         queryKey: ['recordings'],
         queryFn: async () => {
-            const response = await client.api.v1.recordings.$get(
+            const response = await client.api.v1.recordings.user.$get(
                 {},
                 {
                     fetch: appFetch,


### PR DESCRIPTION
- add new `/user` endpoint in recordings controller to fetch user-specific recordings
- implement `findByToken` and `findByUserId` in `RecordingsRepository` using JWT claims
- update dashboard query to use `client.api.v1.recordings.user.$get` (scoped by token)
- fix bug where streak/recording progress was shared across users
- add streak update logic after successful upload
- add Radix `Switch` UI component dependency and wrapper