### PR TITLE
feat(dashboard): improve error handling, retries, and add logout button

### DIFF
--- a/src/modules/authentication/authentication.repository.ts
+++ b/src/modules/authentication/authentication.repository.ts
@@ -7,9 +7,9 @@ type FindByUser = {
     user: number // <- user id
 }
 
-type FindByUsername = {
-    username: string
-}
+// type FindByUsername = {
+//     username: string
+// }
 
 export interface AuthEntity extends Authentication { }
 

--- a/src/modules/recordings/recordings.controller.ts
+++ b/src/modules/recordings/recordings.controller.ts
@@ -157,7 +157,7 @@ export const recordingsController = new Hono()
             const note = formData.get('note') as string | null
             const chapterIdRaw = formData.get('chapter_id') as string | null
             const chapterId = chapterIdRaw ? parseInt(chapterIdRaw) : null
-            
+
             // Validate chapter_id if provided (1-114 for Quran chapters)
             if (chapterId !== null && (isNaN(chapterId) || chapterId < 1 || chapterId > 114)) {
                 return appResponse(c, 400, 'Invalid chapter_id. Must be between 1 and 114.', null)

--- a/src/modules/recordings/recordings.repository.ts
+++ b/src/modules/recordings/recordings.repository.ts
@@ -1,6 +1,6 @@
 
 import { db } from '../../config/db/index.js'
-import { recordingTable, streakTable, type Recording } from '../../config/db/schema/postgres.js'
+import { recordingTable, type Recording } from '../../config/db/schema/postgres.js'
 import { JWTService } from '../../lib/middleware/jwt.js'
 import type { BaseRepository } from '../../lib/repository.js'
 import { eq, count, desc } from 'drizzle-orm'


### PR DESCRIPTION
- add retry logic to recordings & streaks queries (skip retry on 4xx, max 3 attempts)
- add fallback data for recordings (empty array) and streaks (default values)
- simplify loading state (only show loading when both queries are still fetching)
- add logout button with handler to clear auth and redirect to login
- refactor streak rendering to always use StreakCounter
- remove unused import